### PR TITLE
Include power monitoring

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 # events but only for the main branch.
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,7 +44,17 @@ steps you need to complete:
    generic Az-RBSI template contains a team number "0", and your code will not
    deploy properly if this variable is not set (*e.g.*, VSCode looks for the
    RoboRIO on IP address `10.TE.AM.2`, and it will not find anything if it
-   tries to contact `10.0.0.2`.)
+   tries to contact `10.0.0.2`.)  If you forget to change this value, you will
+   get an error message when deploying code to your robot like:
+
+   ```
+   Missing Target!
+   =============================================
+   Are you connected to the robot, and is it on?
+   =============================================
+   GradleRIO detected this build failed due to not being able to find "roborio"!
+   Scroll up in this error log for more information.
+   ```
 
 2. If you have an all-CTRE swerve base (*i.e.*, 8x TalonFX-controlled motors,
    4x CANCoders, and 1x Pigeon2), use Phoenix Tuner X to create a swerve

--- a/README.md
+++ b/README.md
@@ -53,3 +53,8 @@ effective logging for troubleshooting.
 * [PhotonVision](https://docs.photonvision.org/en/latest/) / [Limelight](
   https://docs.limelightvision.io/docs/docs-limelight/getting-started/summary)
   -- Robot vision / tracking
+
+## Further Reading
+
+For tips on command-based programming, see this post:
+https://bovlb.github.io/frc-tips/commands/best-practices.html

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -30,7 +30,6 @@ import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.units.measure.LinearVelocity;
 import edu.wpi.first.wpilibj.Filesystem;
-import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj.RobotBase;
 import frc.robot.generated.TunerConstants;
 import frc.robot.util.Alert;
@@ -102,8 +101,6 @@ public final class Constants {
   /** Power Distribution Constants ********************************** */
   public static final class PowerConstants {
 
-    // Set this to either kRev or kCTRE for the type of Power Distribution Module
-    public static final ModuleType kPowerModule = ModuleType.kRev;
     // Current Limits
     public static final double kTotalMaxCurrent = 120.;
     public static final double kMotorPortMaxCurrent = 40.;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -18,13 +18,10 @@ import edu.wpi.first.wpilibj.Threads;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import frc.robot.Constants.PowerConstants;
-import frc.robot.RobotContainer.Ports;
 import frc.robot.util.VirtualSubsystem;
 import org.littletonrobotics.junction.LogFileUtil;
 import org.littletonrobotics.junction.LoggedRobot;
 import org.littletonrobotics.junction.Logger;
-import org.littletonrobotics.junction.inputs.LoggedPowerDistribution;
 import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGReader;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
@@ -74,8 +71,6 @@ public class Robot extends LoggedRobot {
         // Running on a real robot, log to a USB stick ("/U/logs")
         Logger.addDataReceiver(new WPILOGWriter());
         Logger.addDataReceiver(new NT4Publisher());
-        LoggedPowerDistribution.getInstance(
-            Ports.POWER_CAN_DEVICE_ID.getDeviceNumber(), PowerConstants.kPowerModule);
         break;
 
       case SIM:

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -44,7 +44,6 @@ import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Constants.AprilTagConstants;
 import frc.robot.Constants.AprilTagConstants.AprilTagLayoutType;
-import frc.robot.Constants.PowerConstants;
 import frc.robot.commands.ChoreoAutoController;
 import frc.robot.commands.DriveCommands;
 import frc.robot.subsystems.accelerometer.Accelerometer;
@@ -79,8 +78,10 @@ public class RobotContainer {
   Field2d m_field = new Field2d();
 
   // Declare the robot subsystems here
+  // These are the "Active Subsystems" that the robot controlls
   private final Drive m_drivebase;
   private final Flywheel m_flywheel;
+  // These are "Virtual Subsystems" that report information but have no motors
   private final Accelerometer m_accel;
   private final Vision m_vision;
   private final PowerMonitoring m_power;
@@ -91,6 +92,9 @@ public class RobotContainer {
   private final AutoChooser autoChooserChoreo;
   private final AutoFactory autoFactoryChoreo;
   private final ChoreoAutoController choreoController;
+  // Input estimated battery capacity (if full, use printed value)
+  private final LoggedTunableNumber batteryCapacity =
+      new LoggedTunableNumber("Battery Amp-Hours", 18.0);
   // EXAMPLE TUNABLE FLYWHEEL SPEED INPUT FROM DASHBOARD
   private final LoggedTunableNumber flywheelSpeedInput =
       new LoggedTunableNumber("Flywheel Speed", 1500.0);
@@ -108,7 +112,6 @@ public class RobotContainer {
   }
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
-  @SuppressWarnings("unchecked")
   public RobotContainer() {
 
     // Instantiate Robot Subsystems based on RobotType
@@ -160,10 +163,10 @@ public class RobotContainer {
         break;
     }
 
-    // ``PowerMonitoring`` takes all the non-drivebase subsystems for which
-    //   you wish to have power monitoring; DO NOT include ``m_drivebase``,
-    //   as that is automatically monitored.
-    m_power = null; // new PowerMonitoring(m_flywheel);
+    // In addition to the initial battery capacity from the Dashbaord, ``PowerMonitoring`` takes all
+    // the non-drivebase subsystems for which you wish to have power monitoring; DO NOT include
+    // ``m_drivebase``, as that is automatically monitored.
+    m_power = new PowerMonitoring(batteryCapacity, m_flywheel);
 
     // Set up the SmartDashboard Auto Chooser based on auto type
     switch (Constants.getAutoType()) {
@@ -370,14 +373,6 @@ public class RobotContainer {
     public static final RobotDeviceId BR_CANCODER = new RobotDeviceId(12, "DriveTrain", null);
 
     public static final RobotDeviceId PIGEON = new RobotDeviceId(13, "DriveTrain", null);
-
-    /* POWER DISTRIBUTION CAN ID (set by device type in PowerConstants) */
-    public static final RobotDeviceId POWER_CAN_DEVICE_ID =
-        switch (PowerConstants.kPowerModule) {
-          case kRev -> new RobotDeviceId(1, null);
-          case kCTRE -> new RobotDeviceId(0, null);
-          default -> null;
-        };
 
     /* SUBSYSTEM CAN DEVICE IDS */
     // This is where mechanism subsystem devices are defined

--- a/src/main/java/frc/robot/util/PowerMonitoring.java
+++ b/src/main/java/frc/robot/util/PowerMonitoring.java
@@ -13,12 +13,14 @@
 
 package frc.robot.util;
 
-import edu.wpi.first.wpilibj.PowerDistribution;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants.PowerConstants;
 import frc.robot.RobotContainer.Ports;
 import frc.robot.util.Alert.AlertType;
+import org.littletonrobotics.conduit.ConduitApi;
 import org.littletonrobotics.junction.Logger;
+import org.littletonrobotics.junction.inputs.LoggedPowerDistribution;
 
 /**
  * Power monitoring virtual subsystem that periodically polls the Power Distribution Module. Each
@@ -30,13 +32,23 @@ public class PowerMonitoring extends VirtualSubsystem {
 
   private final RBSISubsystem[] subsystems;
 
-  /** Define the Power Distribution Hardware */
-  private PowerDistribution m_powerModule =
-      new PowerDistribution(
-          Ports.POWER_CAN_DEVICE_ID.getDeviceNumber(), PowerConstants.kPowerModule);
+  // Get the AdvantageKit conduit for pulling PDM information
+  private LoggedPowerDistribution loggedPowerDistribution = LoggedPowerDistribution.getInstance();
+  private ConduitApi conduit = ConduitApi.getInstance();
 
-  private int NUM_PDH_CHANNELS = m_powerModule.getNumChannels();
+  // Define local variables
+  private int NUM_PDH_CHANNELS = conduit.getPDPChannelCount();
   private double[] channelCurrents = new double[NUM_PDH_CHANNELS];
+  private double totalAmpHours = 0.0;
+  private long lastTimestamp = RobotController.getFPGATime(); // In microseconds
+  private double deltaTime = 0.0; // In seconds
+  private double batteryVoltage;
+  private double totalCurrent;
+  private double driveCurrent;
+  private double steerCurrent;
+  private double subsystemCurrent;
+  private LoggedTunableNumber batteryCapacity;
+  private double batteryPercent;
 
   // DRIVE and STEER motor power ports
   private final int[] m_drivePowerPorts = {
@@ -53,7 +65,8 @@ public class PowerMonitoring extends VirtualSubsystem {
   };
 
   // Class method definition, including inputs of optional subsystems
-  public PowerMonitoring(RBSISubsystem... subsystems) {
+  public PowerMonitoring(LoggedTunableNumber batteryCapacity, RBSISubsystem... subsystems) {
+    this.batteryCapacity = batteryCapacity;
     this.subsystems = subsystems;
   }
 
@@ -61,20 +74,30 @@ public class PowerMonitoring extends VirtualSubsystem {
   public void periodic() {
 
     // Check the total robot current and individual port currents against Constants
-    double totalCurrent = m_powerModule.getTotalCurrent();
+    batteryVoltage = conduit.getPDPVoltage();
+    totalCurrent = conduit.getPDPTotalCurrent();
     if (totalCurrent > PowerConstants.kTotalMaxCurrent) {
       new Alert("Total current draw exceeds limit!", AlertType.WARNING).set(true);
     }
     for (int i = 0; i < NUM_PDH_CHANNELS; i++) {
-      channelCurrents[i] = m_powerModule.getCurrent(i);
+      channelCurrents[i] = conduit.getPDPChannelCurrent(i);
       if (channelCurrents[i] > PowerConstants.kMotorPortMaxCurrent) {
         new Alert("Port " + i + " current draw exceeds limit!", AlertType.WARNING).set(true);
       }
     }
+    // Compute the total energy (charge) used in this loop
+    deltaTime =
+        (RobotController.getFPGATime() - lastTimestamp) / 1.0e6; // Time in seconds since last loop
+    lastTimestamp = RobotController.getFPGATime(); // Update timestamp
+    totalAmpHours += (totalCurrent * deltaTime / 3600.);
+
+    // Compute estimated battery life left as a percent
+    batteryPercent =
+        (batteryCapacity.getAsDouble() - totalAmpHours) / batteryCapacity.getAsDouble() * 100;
 
     // Compute DRIVE and STEER summed currents
-    double driveCurrent = 0.0;
-    double steerCurrent = 0.0;
+    driveCurrent = 0.0;
+    steerCurrent = 0.0;
     for (int port : m_drivePowerPorts) {
       driveCurrent += channelCurrents[port];
     }
@@ -82,16 +105,22 @@ public class PowerMonitoring extends VirtualSubsystem {
       steerCurrent += channelCurrents[port];
     }
     // Log values to AdvantageKit and to SmartDashboard
+    Logger.recordOutput("PowerMonitor/Voltage", batteryVoltage);
+    Logger.recordOutput("PowerMonitor/EstimatedBatteryPercent", batteryPercent);
+    Logger.recordOutput("PowerMonitor/AmpHoursUsed", totalAmpHours);
     Logger.recordOutput("PowerMonitor/TotalCurrent", totalCurrent);
     Logger.recordOutput("PowerMonitor/DriveCurrent", driveCurrent);
     Logger.recordOutput("PowerMonitor/SteerCurrent", steerCurrent);
+    SmartDashboard.putNumber("BatteryVoltage", batteryVoltage);
+    SmartDashboard.putNumber("EstimatedBatteryPercent", batteryPercent);
+    SmartDashboard.putNumber("AmpHoursUsed", totalAmpHours);
     SmartDashboard.putNumber("TotalCurrent", totalCurrent);
     SmartDashboard.putNumber("DriveCurrent", driveCurrent);
     SmartDashboard.putNumber("SteerCurrent", steerCurrent);
 
     // Compute and log any passed-in subsystems
     for (RBSISubsystem subsystem : subsystems) {
-      double subsystemCurrent = 0.0;
+      subsystemCurrent = 0.0;
       for (int port : subsystem.getPowerPorts()) {
         subsystemCurrent += channelCurrents[port];
       }
@@ -99,7 +128,7 @@ public class PowerMonitoring extends VirtualSubsystem {
       SmartDashboard.putNumber(subsystem.getName() + "Current", subsystemCurrent);
     }
 
-    // Do something about setting priorities if drawing too much current
+    // TODO: Do something about setting priorities if drawing too much current
 
   }
 }


### PR DESCRIPTION
Power monitoring now available in logs with consolidated mechanism current (_e.g._, drive vs steer vs other subsystems), a measure of total Amp-hours used since the start of the program, and an estimate percentage of battery charge left, with a settable starting A*h in the SmartDashboard.

Fixes #22 