### PR TITLE
Rename default auto paths

### DIFF
--- a/src/main/deploy/pathplanner/autos/Test.auto
+++ b/src/main/deploy/pathplanner/autos/Test.auto
@@ -7,7 +7,7 @@
         {
           "type": "path",
           "data": {
-            "pathName": "Example Path"
+            "pathName": "Consistancy Test"
           }
         }
       ]

--- a/src/main/deploy/pathplanner/paths/Consistancy Test.path
+++ b/src/main/deploy/pathplanner/paths/Consistancy Test.path
@@ -3,41 +3,25 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 2.0,
-        "y": 7.0
+        "x": 9.35,
+        "y": 6.18
       },
       "prevControl": null,
       "nextControl": {
-        "x": 3.013282910175676,
-        "y": 6.5274984191074985
+        "x": 9.29,
+        "y": 6.22
       },
       "isLocked": false,
       "linkedName": null
     },
     {
       "anchor": {
-        "x": 5.166769560390973,
-        "y": 5.0964860911203305
+        "x": 8.18,
+        "y": 6.18
       },
       "prevControl": {
-        "x": 4.166769560390973,
-        "y": 6.0964860911203305
-      },
-      "nextControl": {
-        "x": 6.166769560390973,
-        "y": 4.0964860911203305
-      },
-      "isLocked": false,
-      "linkedName": null
-    },
-    {
-      "anchor": {
-        "x": 7.0,
-        "y": 1.0
-      },
-      "prevControl": {
-        "x": 6.75,
-        "y": 2.5
+        "x": 8.56,
+        "y": 6.17
       },
       "nextControl": null,
       "isLocked": false,
@@ -49,8 +33,8 @@
   "pointTowardsZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 3.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 1.0,
+    "maxAcceleration": 1.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0,
     "nominalVoltage": 12.0,


### PR DESCRIPTION
For some reason, the naming of files was causing PathPlanner to be unhappy.

Resolves #33 .