### PR TITLE
Change Wheel Radius Inches to Meters

### DIFF
--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -59,7 +59,7 @@ public class Module {
     int sampleCount = inputs.odometryTimestamps.length; // All signals are sampled together
     odometryPositions = new SwerveModulePosition[sampleCount];
     for (int i = 0; i < sampleCount; i++) {
-      double positionMeters = inputs.odometryDrivePositionsRad[i] * kWheelRadiusInches;
+      double positionMeters = inputs.odometryDrivePositionsRad[i] * kWheelRadiusMeters;
       Rotation2d angle = inputs.odometryTurnPositions[i];
       odometryPositions[i] = new SwerveModulePosition(positionMeters, angle);
     }


### PR DESCRIPTION
Hi Tim, I noticed that the robot odometry was moving much faster than seems realistic, and I found this issue with the module odometry. Instead of multiplying the radian measurement by the wheel radius in meters, it was originally being multiplied by the radius in inches. Please review this to make sure the change is valid. 