### PR TITLE
Read GameData from the FMS for when a robot's HUB will be active

### DIFF
--- a/src/main/java/frc/robot/FieldState.java
+++ b/src/main/java/frc/robot/FieldState.java
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Az-FIRST
+// http://github.com/AZ-First
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import frc.robot.util.Alert;
+
+public class FieldState {
+
+  /**
+   * FOR 2026 - REBUILT, store the data from the FMS about the TeleOp shifts here
+   *
+   * <p>Once the FMS chooses an alliance, this value will become either 'B' or 'R' for which
+   * alliance's HUB is INACTIVE first.
+   *
+   * <p>If this variable is 'B', then BLUE is ACTIVE during Shift 2 and Shift 4 (and RED is ACTIVE
+   * during Shift 1 and Shift 3).
+   *
+   * <p>If this variable is 'R', then RED is ACTIVE during Shift 2 and Shift 4 (and BLUE is ACTIVE
+   * during Shift 1 and Shift 3).
+   *
+   * <p>========== TESTING ==========
+   *
+   * <p>You can test your Game Specific Data code without FMS by using the Driver Station. Click on
+   * the Setup tab of the Driver Station, then enter the desired test string into the Game Data text
+   * field. The data will be transmitted to the robot in one of two conditions: Enable the robot in
+   * Teleop mode, or when the DS reaches the End Game time in a Practice Match (times are
+   * configurable on the Setup tab). It is recommended to run at least one match using the Practice
+   * functionality to verify that your code works correctly in a full match flow.
+   */
+  public static Alliance wonAuto = null;
+
+  /**
+   * Check whether the HUB is active right now
+   *
+   * @return Whether the team's alliance's HUB is active right now
+   */
+  public static boolean isHubActive() {
+
+    // The HUB is active for both alliances in AUTO
+    if (DriverStation.isAutonomous()) {
+      return true;
+    }
+
+    // The HUB is not active when not in AUTO or TELEOP
+    if (!DriverStation.isTeleop()) {
+      return false;
+    }
+
+    // Read in the current match time & get alliance
+    // TODO: Since the ``DriverStation.getMatchTime()`` returns INT::
+    //       Return the approximate match time. The FMS does not send an
+    //       official match time to the robots, but does send an approximate
+    //       match time. The value will count down the time remaining in the
+    //       current period (auto or teleop). Warning: This is not an official
+    //       time (so it cannot be used to dispute ref calls or guarantee that
+    //       a function will trigger before the match ends).
+    double timeRemaining = DriverStation.getMatchTime();
+    Alliance alliance = DriverStation.getAlliance().orElse(Alliance.Blue);
+
+    // If the FMS has not provided an alliance yet, set to TRUE and kick an Alert!
+    if (timeRemaining < 130.0 && wonAuto == null) {
+      new Alert(
+              "No HUB data from FMS!  HUB is listed as ACTIVE!  Driver BEWARE!",
+              Alert.AlertType.WARNING)
+          .set(true);
+      return true;
+    }
+
+    if (timeRemaining >= 130.0) {
+      // TRANSITION SHIFT -- Both HUBs active
+      return true;
+
+    } else if (timeRemaining >= 105.0) {
+      // SHIFT 1 -- Non-winning alliance gets a first go
+      return !(wonAuto == alliance);
+
+    } else if (timeRemaining >= 80.0) {
+      // SHIFT 2 -- Winning alliance gets a chance
+      return (wonAuto == alliance);
+
+    } else if (timeRemaining >= 55.0) {
+      // SHIFT 3 -- Trade off
+      return !(wonAuto == alliance);
+
+    } else if (timeRemaining >= 30.0) {
+      // SHIFT 4 -- Trade off again
+      return (wonAuto == alliance);
+
+    } else {
+      // ENDGAME -- Both HUBs active
+      return true;
+    }
+  }
+}

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -18,6 +18,7 @@
 package frc.robot;
 
 import com.revrobotics.util.StatusLogger;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Threads;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -191,7 +192,36 @@ public class Robot extends LoggedRobot {
 
   /** This function is called periodically during operator control. */
   @Override
-  public void teleopPeriodic() {}
+  public void teleopPeriodic() {
+
+    // For 2026 - REBUILT, the alliance will be provided as a single character
+    //   representing the color of the alliance whose goal will go inactive
+    //   first (i.e. ‘R’ = red, ‘B’ = blue). This alliance’s goal will be
+    //   active in Shifts 2 and 4.
+    //
+    // https://docs.wpilib.org/en/stable/docs/yearly-overview/2026-game-data.html
+    if (FieldState.wonAuto == null) {
+      // Only call this code block if the signal from FMS has not yet arrived
+      String gameData = DriverStation.getGameSpecificMessage();
+      if (gameData.length() > 0) {
+        switch (gameData.charAt(0)) {
+          case 'B':
+            // Blue case code
+            FieldState.wonAuto = DriverStation.Alliance.Blue;
+            break;
+          case 'R':
+            // Red case code
+            FieldState.wonAuto = DriverStation.Alliance.Red;
+            break;
+          default:
+            // This is corrupt data, do nothing
+            break;
+        }
+      }
+    }
+    // Anything else for the teleopPeriodic() function
+
+  }
 
   /** This function is called once when test mode is enabled. */
   @Override


### PR DESCRIPTION
The status of both HUBS during the ALLIANCE SHIFTS is based on the results of AUTO. The ALLIANCE that scores the most FUEL during AUTO will have their HUB set to inactive for SHIFT 1 while their opponent's HUB will be active

This commit adds the basic machinery to read the FMS data and provides a boolean function that returns whether the robot's alliance HUB is active at the present moment.